### PR TITLE
slides/Lecture1: specify value as non-zero in ring

### DIFF
--- a/slides/Lecture1.tex
+++ b/slides/Lecture1.tex
@@ -242,11 +242,13 @@ We say $r\in R$ is a \emph{unit} if there exists an element $s\in R$ with $rs=1_
 \end{definition}
 
 \begin{definition}
-We say that $r\in R$ is a \emph{zero divisor} if there exists $s\in R, s\neq 0_R$ with $rs=0_R$
+We say that $r\in R, r\neq 0_R$ is a \emph{zero divisor}
+if there exists $s\in R, s\neq 0_R$ with $rs=0_R$
 \end{definition}
 
 \begin{definition}
-We say that $r\in R$ is \emph{nilpotent} if there exists some $n\in\mathbb{N}$ with $r^n=0_R$
+We say that $r\in R, r\neq 0_R$ is \emph{nilpotent}
+if there exists some $n\in\mathbb{N}$ with $r^n=0_R$
 \end{definition}
 
 \begin{block}{Examples?}


### PR DESCRIPTION
The definitions of a zero divisor and nilpotent should explicitly exclude zero.